### PR TITLE
Correct initialisation of s_zEnabled

### DIFF
--- a/src/engine/graphics/core/device.cpp
+++ b/src/engine/graphics/core/device.cpp
@@ -28,7 +28,7 @@ namespace graphics {
 	ComparisonFunc Device::s_stencilFuncBack	= ComparisonFunc::ALWAYS;
 	bool Device::s_stencilEnable				= false;
 	ComparisonFunc Device::s_zFunc				= ComparisonFunc::ALWAYS;
-	bool Device::s_zEnable						= true;
+	bool Device::s_zEnable						= false;
 	bool Device::s_zWriteEnable					= true;
 	bool Device::s_scissorEnable				= true;
 	GLFWwindow* Device::s_window				= nullptr;


### PR DESCRIPTION
Was enabled with true instead of false, so the depth test was not
enabled when a depth function is set.

```c++
graphics::Device::setZFunc(ComparisonFunc::LESS); // no depth test enabled
```
